### PR TITLE
將 windows 10 的 Docker image 列為測試方案

### DIFF
--- a/tested/Dockerfile.win10
+++ b/tested/Dockerfile.win10
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/windows:2004
+RUN curl -L -o C:\pythoninstaller.exe https://www.python.org/ftp/python/3.7.7/python-3.7.7-amd64.exe
+RUN powershell -c "Start-Process C:\pythoninstaller.exe -Wait -ArgumentList @( '/passive','InstallAllUsers=1', 'TargetDir=C:\Python', 'PrependPath=1', 'Shortcuts=0','Include_doc=0','Include_pip=1', 'Include_test=0')"
+RUN powershell -c "$env:PATH = [Environment]::GetEnvironmentVariable('PATH',[EnvironmentVariableTarget]::Machine)"
+RUN powershell -c "python -m pip install --upgrade pip"
+RUN powershell -c "python -m pip install skcom"
+#RUN powershell -c "python -m skcom.tools.setup"
+
+CMD ["cmd"]


### PR DESCRIPTION
雖然 Docker for Windows 的 Windows Container 方案仍有諸多限制 (要開企業版才有的 Hyper-V 功能, 無法運行 GUI, image 容量肥大[12~13GB])

但由於依然有原生 Windows 環境的特性與兼顧容器功能的考量，或許還是可以作為其中一個研究方案

目前會因為沒有 GUI 而造成的問題就是在執行 `regsvr32` 指令時會因為提示視窗無法關掉而卡住，雖然手動 Ctrl-C 後重新跑 `python -m skcom.tools.setup` 就過了，但因為會對自動化流程有諸多不便，因此還是在 https://github.com/tacosync/skcom/pull/78 問問看套件作者能不能調整了。

![圖片](https://user-images.githubusercontent.com/31742569/83354825-d3f53480-a38d-11ea-9399-8bf4d1d22fb3.png)

其他因為我沒用過該家證券公司的 API，有無 GUI 會有什麼我也不太清楚，但就是列一個原生容器的方案供參

其他方向：看把 base image 換成 windows server core 是否可行，因為 windows 10 1909/2004 系列的 docker image 還是肥得太誇張了